### PR TITLE
Block map adapting for Python3

### DIFF
--- a/python/straw.py
+++ b/python/straw.py
@@ -426,7 +426,7 @@ def straw(norm, infile, chr1loc, chr2loc, unit, binsize):
        binsize(int): Resolution, i.e. 25000 for 25K
     """
     # clear the global variable blockMap so that it won't keep the data from previous calls
-    for blockNum in blockMap.keys():
+    for blockNum in list(blockMap.keys()):
         blockMap.pop(blockNum)
 
     magic_string = ""


### PR DESCRIPTION
dict.keys() returns a generator in Python 3, but
in Python 2 it returns a list. Hence, iterating and modifying
dict.keys() will fail, because the dict changes on the fly.

Signed-off-by: Yossi Eliaz <eliaz123@gmail.com>